### PR TITLE
Fix gofuzz batch test

### DIFF
--- a/op-node/rollup/derive/batch_tob_test.go
+++ b/op-node/rollup/derive/batch_tob_test.go
@@ -16,6 +16,22 @@ func FuzzBatchRoundTrip(f *testing.F) {
 		typeProvider := fuzz.NewFromGoFuzz(fuzzedData).NilChance(0).MaxDepth(10000).NumElements(0, 0x100).AllowUnexportedFields(true)
 		fuzzerutils.AddFuzzerFunctions(typeProvider)
 
+		// Add an extra fuzzer that respects constraints of V1 vs V2 batch
+		typeProvider.Funcs(
+			func(e *BatchData, c fuzz.Continue) {
+				// Only 0 and 1 are valid versions.
+				e.Version = c.Intn(2)
+
+				// Fuzz the PayToAddr for v2 batches
+				if e.Version == 1 {
+					c.Fuzz(&e.BatchV2.PayToAddr)
+				}
+
+				// Fuzz the rest of the batch data
+				c.Fuzz(&e.BatchV2.BatchV1)
+			},
+		)
+
 		// Create our batch data from fuzzed data
 		var batchData BatchData
 		typeProvider.Fuzz(&batchData)


### PR DESCRIPTION
Other than constraining the version we also need to not have a PayToAddr in v1 batches because those will de zero after deserializing.