### PR TITLE
T71 fund batchers addresses

### DIFF
--- a/op-e2e/e2eutils/secrets.go
+++ b/op-e2e/e2eutils/secrets.go
@@ -27,10 +27,6 @@ var DefaultMnemonicConfig = &MnemonicConfig{
 	Bob:          "m/44'/60'/0'/0/7",
 	Mallory:      "m/44'/60'/0'/0/8",
 	SysCfgOwner:  "m/44'/60'/0'/0/9",
-	Batcher1:     "m/44'/60'/0'/0/10",
-	Batcher2:     "m/44'/60'/0'/0/11",
-	Batcher3:     "m/44'/60'/0'/0/12",
-	Batcher4:     "m/44'/60'/0'/0/13",
 }
 
 // MnemonicConfig configures the private keys for the hive testnet.
@@ -51,11 +47,6 @@ type MnemonicConfig struct {
 	Alice   string
 	Bob     string
 	Mallory string
-
-	Batcher1 string
-	Batcher2 string
-	Batcher3 string
-	Batcher4 string
 }
 
 // Secrets computes the private keys for all mnemonic paths,
@@ -105,22 +96,6 @@ func (m *MnemonicConfig) Secrets() (*Secrets, error) {
 	if err != nil {
 		return nil, err
 	}
-	batcher1, err := wallet.PrivateKey(account(m.Batcher1))
-	if err != nil {
-		return nil, err
-	}
-	batcher2, err := wallet.PrivateKey(account(m.Batcher2))
-	if err != nil {
-		return nil, err
-	}
-	batcher3, err := wallet.PrivateKey(account(m.Batcher3))
-	if err != nil {
-		return nil, err
-	}
-	batcher4, err := wallet.PrivateKey(account(m.Batcher4))
-	if err != nil {
-		return nil, err
-	}
 
 	return &Secrets{
 		Deployer:     deployer,
@@ -133,10 +108,6 @@ func (m *MnemonicConfig) Secrets() (*Secrets, error) {
 		Bob:          bob,
 		Mallory:      mallory,
 		Wallet:       wallet,
-		Batcher1:     batcher1,
-		Batcher2:     batcher2,
-		Batcher3:     batcher3,
-		Batcher4:     batcher4,
 	}, nil
 }
 
@@ -158,12 +129,6 @@ type Secrets struct {
 
 	// Share the wallet to be able to generate more accounts
 	Wallet *hdwallet.Wallet
-
-	// Batchers for testing
-	Batcher1 *ecdsa.PrivateKey
-	Batcher2 *ecdsa.PrivateKey
-	Batcher3 *ecdsa.PrivateKey
-	Batcher4 *ecdsa.PrivateKey
 }
 
 // EncodePrivKey encodes the given private key in 32 bytes
@@ -191,10 +156,6 @@ func (s *Secrets) Addresses() *Addresses {
 		Alice:        crypto.PubkeyToAddress(s.Alice.PublicKey),
 		Bob:          crypto.PubkeyToAddress(s.Bob.PublicKey),
 		Mallory:      crypto.PubkeyToAddress(s.Mallory.PublicKey),
-		Batcher1:     crypto.PubkeyToAddress(s.Batcher1.PublicKey),
-		Batcher2:     crypto.PubkeyToAddress(s.Batcher2.PublicKey),
-		Batcher3:     crypto.PubkeyToAddress(s.Batcher3.PublicKey),
-		Batcher4:     crypto.PubkeyToAddress(s.Batcher3.PublicKey),
 	}
 }
 
@@ -213,12 +174,6 @@ type Addresses struct {
 	Alice   common.Address
 	Bob     common.Address
 	Mallory common.Address
-
-	// Batchers for testing
-	Batcher1 common.Address
-	Batcher2 common.Address
-	Batcher3 common.Address
-	Batcher4 common.Address
 }
 
 func (a *Addresses) All() []common.Address {
@@ -232,9 +187,5 @@ func (a *Addresses) All() []common.Address {
 		a.Alice,
 		a.Bob,
 		a.Mallory,
-		a.Batcher1,
-		a.Batcher2,
-		a.Batcher3,
-		a.Batcher4,
 	}
 }

--- a/op-e2e/e2eutils/secrets.go
+++ b/op-e2e/e2eutils/secrets.go
@@ -27,6 +27,10 @@ var DefaultMnemonicConfig = &MnemonicConfig{
 	Bob:          "m/44'/60'/0'/0/7",
 	Mallory:      "m/44'/60'/0'/0/8",
 	SysCfgOwner:  "m/44'/60'/0'/0/9",
+	Batcher1:     "m/44'/60'/0'/0/10",
+	Batcher2:     "m/44'/60'/0'/0/11",
+	Batcher3:     "m/44'/60'/0'/0/12",
+	Batcher4:     "m/44'/60'/0'/0/13",
 }
 
 // MnemonicConfig configures the private keys for the hive testnet.
@@ -47,6 +51,11 @@ type MnemonicConfig struct {
 	Alice   string
 	Bob     string
 	Mallory string
+
+	Batcher1 string
+	Batcher2 string
+	Batcher3 string
+	Batcher4 string
 }
 
 // Secrets computes the private keys for all mnemonic paths,
@@ -96,6 +105,22 @@ func (m *MnemonicConfig) Secrets() (*Secrets, error) {
 	if err != nil {
 		return nil, err
 	}
+	batcher1, err := wallet.PrivateKey(account(m.Batcher1))
+	if err != nil {
+		return nil, err
+	}
+	batcher2, err := wallet.PrivateKey(account(m.Batcher2))
+	if err != nil {
+		return nil, err
+	}
+	batcher3, err := wallet.PrivateKey(account(m.Batcher3))
+	if err != nil {
+		return nil, err
+	}
+	batcher4, err := wallet.PrivateKey(account(m.Batcher4))
+	if err != nil {
+		return nil, err
+	}
 
 	return &Secrets{
 		Deployer:     deployer,
@@ -108,6 +133,10 @@ func (m *MnemonicConfig) Secrets() (*Secrets, error) {
 		Bob:          bob,
 		Mallory:      mallory,
 		Wallet:       wallet,
+		Batcher1:     batcher1,
+		Batcher2:     batcher2,
+		Batcher3:     batcher3,
+		Batcher4:     batcher4,
 	}, nil
 }
 
@@ -129,6 +158,12 @@ type Secrets struct {
 
 	// Share the wallet to be able to generate more accounts
 	Wallet *hdwallet.Wallet
+
+	// Batchers for testing
+	Batcher1 *ecdsa.PrivateKey
+	Batcher2 *ecdsa.PrivateKey
+	Batcher3 *ecdsa.PrivateKey
+	Batcher4 *ecdsa.PrivateKey
 }
 
 // EncodePrivKey encodes the given private key in 32 bytes
@@ -156,6 +191,10 @@ func (s *Secrets) Addresses() *Addresses {
 		Alice:        crypto.PubkeyToAddress(s.Alice.PublicKey),
 		Bob:          crypto.PubkeyToAddress(s.Bob.PublicKey),
 		Mallory:      crypto.PubkeyToAddress(s.Mallory.PublicKey),
+		Batcher1:     crypto.PubkeyToAddress(s.Batcher1.PublicKey),
+		Batcher2:     crypto.PubkeyToAddress(s.Batcher2.PublicKey),
+		Batcher3:     crypto.PubkeyToAddress(s.Batcher3.PublicKey),
+		Batcher4:     crypto.PubkeyToAddress(s.Batcher3.PublicKey),
 	}
 }
 
@@ -174,6 +213,12 @@ type Addresses struct {
 	Alice   common.Address
 	Bob     common.Address
 	Mallory common.Address
+
+	// Batchers for testing
+	Batcher1 common.Address
+	Batcher2 common.Address
+	Batcher3 common.Address
+	Batcher4 common.Address
 }
 
 func (a *Addresses) All() []common.Address {
@@ -187,5 +232,9 @@ func (a *Addresses) All() []common.Address {
 		a.Alice,
 		a.Bob,
 		a.Mallory,
+		a.Batcher1,
+		a.Batcher2,
+		a.Batcher3,
+		a.Batcher4,
 	}
 }

--- a/op-e2e/leader_election_test.go
+++ b/op-e2e/leader_election_test.go
@@ -2,10 +2,11 @@ package op_e2e
 
 import (
 	"context"
-	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
@@ -28,17 +29,13 @@ func TestLeaderElectionSetup(t *testing.T) {
 	InitParallel(t)
 
 	cfg := DefaultSystemConfig(t)
-
-	sys, err := cfg.Start(t)
+	NumberOfLeaders := int(cfg.DeployConfig.LeaderElectionNumberOfLeaders)
+	sys, accounts, err := startConfigWithTestAccounts(t, &cfg, NumberOfLeaders)
 	require.Nil(t, err, "Error starting up system")
 	defer sys.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-
-	//opGeth, err := NewOpGeth(t, ctx, &cfg)
-	//require.NoError(t, err)
-	//defer opGeth.Close()
 
 	opts, err := bind.NewKeyedTransactorWithChainID(sys.cfg.Secrets.Alice, cfg.L1ChainIDBig())
 	log.Info(opts.GasPrice.String())
@@ -56,31 +53,31 @@ func TestLeaderElectionSetup(t *testing.T) {
 	require.Nil(t, err)
 
 	// Initialize the Leader Election Batch Inbox contract with the addresses of the Batchers
-	sys.InitLeaderBatchInboxContract(t)
+	batcherAddresses := make([]common.Address, 0, NumberOfLeaders)
+	for i := 0; i < NumberOfLeaders; i++ {
+		batcherAddresses = append(batcherAddresses, accounts[i].Addr)
+	}
+	sys.InitLeaderBatchInboxContract(t, batcherAddresses)
 
 	// Check that the leader slots are correctly filled
-	NumberOfLeaders := int(cfg.DeployConfig.LeaderElectionNumberOfLeaders)
+
 	NumberOfSlotsPerLeader := int(cfg.DeployConfig.LeaderElectionNumberOfSlotsPerLeader)
 	blockNumberOfBatchInboxContractDeployment, err := leaderElectionContract.CreationBlockNumber(&bind.CallOpts{})
 	require.Nil(t, err)
 	blockNumberOfBatchInboxContractDeploymentInt := int(blockNumberOfBatchInboxContractDeployment.Int64())
 
-	// Check the address of each batcher is assigned the right leader slot
+	// Check the address of each batcher is assigned to the right leader slot and that it is funded
+	expectedBalance := new(big.Int)
+	expectedBalance, _ = expectedBalance.SetString("1000000000000000000000000", 10)
 	for i := 0; i < NumberOfLeaders; i++ {
-		batcherAddress := sys.BatchSubmitters[i].TxManager.From()
+		batcherAddress := accounts[i].Addr
+		addressBalance, err := l1Client.BalanceAt(ctx, batcherAddress, nil)
+		require.NoError(t, err)
+		require.Equal(t, expectedBalance, addressBalance, "Batcher address does not seem to be funded.")
 
 		for j := 0; j < NumberOfSlotsPerLeader; j++ {
 			blockNumber := blockNumberOfBatchInboxContractDeploymentInt + i*NumberOfSlotsPerLeader + j
 			checkIsLeader(t, leaderElectionContract, batcherAddress, big.NewInt(int64(blockNumber)))
 		}
-	}
-
-	// Check that each batcher address is funded
-	deployerBalance, err := l1Client.BalanceAt(ctx, sys.cfg.Secrets.Addresses().Deployer, nil)
-	for i := 0; i < NumberOfLeaders; i++ {
-		batcherAddress := sys.BatchSubmitters[i].TxManager.From()
-		addressBalance, err := l1Client.BalanceAt(ctx, batcherAddress, nil)
-		require.NoError(t, err)
-		require.Equal(t, deployerBalance, addressBalance, "Batcher address does not seem to be funded.")
 	}
 }

--- a/op-e2e/leader_election_test.go
+++ b/op-e2e/leader_election_test.go
@@ -55,15 +55,13 @@ func TestLeaderElectionSetup(t *testing.T) {
 	require.Nil(t, err)
 
 	// Initialize the Leader Election Batch Inbox contract with the addresses of the Batchers
-	batchersAddresses := make([]common.Address, 0, NumberOfLeaders)
 	batchersSecrets := make([]*ecdsa.PrivateKey, 0, NumberOfLeaders)
 	for i := 0; i < NumberOfLeaders; i++ {
-		batchersAddresses = append(batchersAddresses, accounts[i].Addr)
 		batchersSecrets = append(batchersSecrets, accounts[i].Key)
 	}
 	err = sys.setBatchers(batchersSecrets)
 	require.Nil(t, err)
-	sys.InitLeaderBatchInboxContract(t, batchersAddresses)
+	sys.InitLeaderBatchInboxContract(t)
 
 	NumberOfSlotsPerLeader := int(cfg.DeployConfig.LeaderElectionNumberOfSlotsPerLeader)
 	blockNumberOfBatchInboxContractDeployment, err := leaderElectionContract.CreationBlockNumber(&bind.CallOpts{})

--- a/op-e2e/leader_election_test.go
+++ b/op-e2e/leader_election_test.go
@@ -1,10 +1,11 @@
 package op_e2e
 
 import (
+	"context"
+	"github.com/ethereum/go-ethereum/common"
 	"math/big"
 	"testing"
-
-	"github.com/ethereum/go-ethereum/common"
+	"time"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
 	"github.com/ethereum-optimism/optimism/op-node/testlog"
@@ -32,6 +33,13 @@ func TestLeaderElectionSetup(t *testing.T) {
 	require.Nil(t, err, "Error starting up system")
 	defer sys.Close()
 
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	//opGeth, err := NewOpGeth(t, ctx, &cfg)
+	//require.NoError(t, err)
+	//defer opGeth.Close()
+
 	opts, err := bind.NewKeyedTransactorWithChainID(sys.cfg.Secrets.Alice, cfg.L1ChainIDBig())
 	log.Info(opts.GasPrice.String())
 	require.Nil(t, err)
@@ -57,11 +65,22 @@ func TestLeaderElectionSetup(t *testing.T) {
 	require.Nil(t, err)
 	blockNumberOfBatchInboxContractDeploymentInt := int(blockNumberOfBatchInboxContractDeployment.Int64())
 
+	// Check the address of each batcher is assigned the right leader slot
 	for i := 0; i < NumberOfLeaders; i++ {
 		batcherAddress := sys.BatchSubmitters[i].TxManager.From()
+
 		for j := 0; j < NumberOfSlotsPerLeader; j++ {
 			blockNumber := blockNumberOfBatchInboxContractDeploymentInt + i*NumberOfSlotsPerLeader + j
 			checkIsLeader(t, leaderElectionContract, batcherAddress, big.NewInt(int64(blockNumber)))
 		}
+	}
+
+	// Check that each batcher address is funded
+	deployerBalance, err := l1Client.BalanceAt(ctx, sys.cfg.Secrets.Addresses().Deployer, nil)
+	for i := 0; i < NumberOfLeaders; i++ {
+		batcherAddress := sys.BatchSubmitters[i].TxManager.From()
+		addressBalance, err := l1Client.BalanceAt(ctx, batcherAddress, nil)
+		require.NoError(t, err)
+		require.Equal(t, deployerBalance, addressBalance, "Batcher address does not seem to be funded.")
 	}
 }

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -3,7 +3,6 @@ package op_e2e
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rand"
 	"fmt"
 	"math/big"
@@ -312,6 +311,7 @@ func addNewLeader(t *testing.T, sys *System, address common.Address) {
 func (sys *System) InitLeaderBatchInboxContract(t *testing.T) {
 
 	NumberOfLeaders := int(sys.cfg.DeployConfig.LeaderElectionNumberOfLeaders)
+	require.Equal(t, 4, NumberOfLeaders, "The set of batchers is hardcoded for testing purposes.")
 
 	for i := 0; i < NumberOfLeaders; i++ {
 		batchSubmitterAddress := sys.BatchSubmitters[i].TxManager.From()
@@ -697,17 +697,14 @@ func (cfg SystemConfig) Start(t *testing.T, _opts ...SystemConfigOption) (*Syste
 	sys.BatchSubmitter, err = genNewBatchSubmitter(sys, cfg, secret)
 
 	MaxNumberParticipants := int(cfg.DeployConfig.LeaderElectionNumberOfLeaders)
+	require.Equal(t, 4, MaxNumberParticipants, "The set of batchers is hardcoded for testing purposes.")
+	secrets := []*ecdsa.PrivateKey{sys.cfg.Secrets.Batcher1, sys.cfg.Secrets.Batcher2, sys.cfg.Secrets.Batcher3, sys.cfg.Secrets.Batcher4}
 	for i := 0; i < MaxNumberParticipants; i++ {
-		priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		if err != nil {
-			return nil, fmt.Errorf("failed to setup batch submitters: %w", err)
-		}
-		newBatchSubmitter, err := genNewBatchSubmitter(sys, cfg, priv)
+		newBatchSubmitter, err := genNewBatchSubmitter(sys, cfg, secrets[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to setup batch submitters: %w", err)
 		}
 		sys.BatchSubmitters = append(sys.BatchSubmitters, newBatchSubmitter)
-
 	}
 
 	if err != nil {

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -308,13 +308,12 @@ func addNewLeader(t *testing.T, sys *System, address common.Address) {
 }
 
 // Initialize the leaders' slots of the Leader Election Batch Inbox contract with the addresses of the batch submitters
-func (sys *System) InitLeaderBatchInboxContract(t *testing.T) {
+func (sys *System) InitLeaderBatchInboxContract(t *testing.T, addresses []common.Address) {
 
 	NumberOfLeaders := int(sys.cfg.DeployConfig.LeaderElectionNumberOfLeaders)
-	require.Equal(t, 4, NumberOfLeaders, "The set of batchers is hardcoded for testing purposes.")
 
 	for i := 0; i < NumberOfLeaders; i++ {
-		batchSubmitterAddress := sys.BatchSubmitters[i].TxManager.From()
+		batchSubmitterAddress := addresses[i]
 		addNewLeader(t, sys, batchSubmitterAddress)
 	}
 }

--- a/op-e2e/setup.go
+++ b/op-e2e/setup.go
@@ -308,12 +308,12 @@ func addNewLeader(t *testing.T, sys *System, address common.Address) {
 }
 
 // Initialize the leaders' slots of the Leader Election Batch Inbox contract with the addresses of the batch submitters
-func (sys *System) InitLeaderBatchInboxContract(t *testing.T, addresses []common.Address) {
+func (sys *System) InitLeaderBatchInboxContract(t *testing.T) {
 
 	NumberOfLeaders := int(sys.cfg.DeployConfig.LeaderElectionNumberOfLeaders)
 
 	for i := 0; i < NumberOfLeaders; i++ {
-		batchSubmitterAddress := addresses[i]
+		batchSubmitterAddress := sys.BatchSubmitters[i].TxManager.From()
 		addNewLeader(t, sys, batchSubmitterAddress)
 	}
 }


### PR DESCRIPTION
Fund the addresses of the batchers in the `sys` object used for testing.
Closes #71 
